### PR TITLE
fix: Correctly handle artifact compression for Windows in build-relea…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -53,8 +53,10 @@ jobs:
           OS="${{ runner.os }}"
           if [[ "$OS" == "Linux" ]]; then
             tar -czvf S3Ducky-${OS}.tar.gz S3Ducky-${OS}
-          else
+          elif [[ "$OS" == "macOS" ]]; then
             zip S3Ducky-${OS}.zip S3Ducky-${OS}
+          elif [[ "$OS" == "Windows" ]]; then
+            powershell -Command "Compress-Archive -Path S3Ducky-${OS}.exe -DestinationPath S3Ducky-${OS}.zip"
           fi
         shell: bash
 


### PR DESCRIPTION
…se workflow

## Summary by Sourcery

Fix the build-release GitHub Actions workflow to correctly compress artifacts on Windows and separate macOS compression handling

Bug Fixes:
- Correct artifact compression step for Windows builds

CI:
- Add explicit PowerShell Compress-Archive step for Windows artifacts
- Refactor OS conditional to handle macOS and Windows separately