### PR TITLE
feat: Add step to create and push Git tag in build-release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -91,6 +91,13 @@ jobs:
           echo "RELEASE_TAG=$VERSION" >> $GITHUB_ENV
           echo "release_tag=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Create and Push Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ env.RELEASE_TAG }}
+          git push origin ${{ env.RELEASE_TAG }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add a workflow step to configure git, create the release tag, and push it to origin before creating the GitHub Release