### PR TITLE
fix: Add permissions for contents in GitHub Release job

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -72,6 +72,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Grant contents: write permission to the Create GitHub Release workflow job