### PR TITLE
fix: Ensure dependencies are installed from requirements.txt if it ex…

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install pyinstaller
 
       - name: Build Executable


### PR DESCRIPTION
…ists

## Summary by Sourcery

CI:
- Add conditional pip install -r requirements.txt step before installing PyInstaller in the build-release workflow