### PR TITLE
fix: Ensure dependencies are always installed from requirements.txt

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r requirements.txt
           pip install pyinstaller
 
       - name: Build Executable


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove conditional check and run pip install -r requirements.txt unconditionally in build-release workflow